### PR TITLE
[Feat] 버스 혼잡도 정보 구하기

### DIFF
--- a/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Comfort.colorset/Contents.json
+++ b/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Comfort.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xAA",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xAA",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Contents.json
+++ b/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Crowded.colorset/Contents.json
+++ b/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Crowded.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Normal.colorset/Contents.json
+++ b/ComfortableMove/ComfortableMove/App/Resources/Assets.xcassets/Color/Congestion/Normal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xA5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xA5",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ComfortableMove/ComfortableMove/Core/Manager/APIManager.swift
+++ b/ComfortableMove/ComfortableMove/Core/Manager/APIManager.swift
@@ -1,8 +1,0 @@
-//
-//  APIManager.swift
-//  ComfortableMove
-//
-//  Created by 박성근 on 9/30/25.
-//
-
-import Foundation

--- a/ComfortableMove/ComfortableMove/Core/Manager/BusArrivalService.swift
+++ b/ComfortableMove/ComfortableMove/Core/Manager/BusArrivalService.swift
@@ -54,6 +54,11 @@ class BusArrivalService {
         let items = result.msgBody.itemList ?? []
         Logger.log(message: "🚌 [API] Retrieved \(items.count) bus routes")
 
+        // 혼잡도 디버깅
+        for item in items {
+            Logger.log(message: "🚌 [API] Route: \(item.rtNm), congestion1: \(item.congestion1 ?? "nil"), congestion: \(item.congestion.rawValue)")
+        }
+
         return items
     }
 }

--- a/ComfortableMove/ComfortableMove/Core/Model/BusArrivalResponse.swift
+++ b/ComfortableMove/ComfortableMove/Core/Model/BusArrivalResponse.swift
@@ -124,6 +124,41 @@ struct MsgBody: Codable {
     let itemList: [BusArrivalItem]?
 }
 
+// MARK: - 버스 혼잡도
+enum BusCongestion: String {
+    case empty = "여유"
+    case normal = "보통"
+    case crowded = "혼잡"
+    case unknown = ""
+
+    var color: Color {
+        switch self {
+        case .empty:
+            return Color("Comfort")
+        case .normal:
+            return Color("Normal")
+        case .crowded:
+            return Color("Crowded")
+        case .unknown:
+            return Color.gray
+        }
+    }
+
+    static func from(code: String?) -> BusCongestion {
+        guard let code = code else { return .unknown }
+        switch code {
+        case "0", "3":
+            return .empty
+        case "4":
+            return .normal
+        case "5", "6":
+            return .crowded
+        default:
+            return .unknown
+        }
+    }
+}
+
 // MARK: - 버스 도착 정보 아이템
 struct BusArrivalItem: Codable {
     let rtNm: String           // 노선명 (예: "721")
@@ -132,9 +167,15 @@ struct BusArrivalItem: Codable {
     let routeType: String      // 노선유형 (3:간선, 4:지선 등)
     let isFullFlag1: String?   // 만차 여부 (0:만차아님, 1:만차)
     let isLast1: String?       // 막차 여부 (0:막차아님, 1:막차)
+    let congestion1: String?    // 첫번째 버스 혼잡도 (3:여유, 4:보통, 5:혼잡)
 
     // 버스 번호로부터 계산된 노선 유형
     var busType: BusRouteType {
         return BusRouteType.from(busNumber: rtNm)
+    }
+
+    // 혼잡도
+    var congestion: BusCongestion {
+        return BusCongestion.from(code: congestion1)
     }
 }

--- a/ComfortableMove/ComfortableMove/Core/Presentation/Home/HomeView.swift
+++ b/ComfortableMove/ComfortableMove/Core/Presentation/Home/HomeView.swift
@@ -147,10 +147,18 @@ struct HomeView: View {
                                                 }
                                             }
 
-                                            if let arrivalMsg = arrivalInfo.arrmsg1 {
-                                                Text(arrivalMsg)
-                                                    .moveFont(.caption)
-                                                    .foregroundColor(.gray)
+                                            HStack(spacing: 4) {
+                                                if let arrivalMsg = arrivalInfo.arrmsg1 {
+                                                    Text(arrivalMsg)
+                                                        .moveFont(.caption)
+                                                        .foregroundColor(.gray)
+                                                }
+
+                                                if arrivalInfo.congestion != .unknown {
+                                                    Text(arrivalInfo.congestion.rawValue)
+                                                        .moveFont(.caption)
+                                                        .foregroundColor(arrivalInfo.congestion.color)
+                                                }
                                             }
 
                                             if let direction = arrivalInfo.adirection {


### PR DESCRIPTION
#35 

### 개요: 버스 혼잡도 정보 구하기
- BusArrivalResponse.swift
    - BusCongestion enum 추가
        - empty(여유): 0, 3 → Color("Comfort")
        - normal(보통): 4 → Color("Normal")
        - crowded(혼잡): 5, 6 → Color("Crowded")
    - BusArrivalItem에 congestion1 필드 추가 (API 응답에서 구할 수 있음)
- HomeView.swift
    - 도착 메시지(몇분후) 옆에 혼잡도 텍스트 표시
    - arrivalInfo.congestion.rawValue로 텍스트, .color로 색상 적용

### 테스트
<img width="295" height="639" alt="스크린샷, 2025-12-17 오후 12 56 49" src="https://github.com/user-attachments/assets/9df8e055-3ebb-4f04-bea4-6689f852a569" />
